### PR TITLE
[WALLPAPERS] Simplify make-zip.sh logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-output/
+wallpapers.zip

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ If any changes are made to the `wallpapers` repository, then the wallpaper manag
 1. Hold a poll or create a pull request before making any significant changes to the `wallpapers` repository.
 2. Update the `wallpapers` repository.
 3. Run `./make-zip.sh` on the latest `wallpapers` local repository.
-4. The file `output/wallpapers.zip` will be generated.
+4. The file `wallpapers.zip` will be generated.
 5. Release the new `wallpapers.zip` on the `reactos/wallpapers` `Releases` page ( https://github.com/reactos/wallpapers/releases ) with a new version tag (`v???`).
 6. Update the data file `roswallp.txt` on `reactos/rapps-db` by comparing it with this repository's [`roswallp-sample.txt`](roswallp-sample.txt) (See `TODO:` parts).

--- a/make-zip.sh
+++ b/make-zip.sh
@@ -7,49 +7,50 @@ then
     exit 1
 fi
 
-OLD_DIR=`pwd`
-NEW_DIR=$(dirname "$0")
-echo "make-zip.sh: NEW_DIR=$NEW_DIR"
-
-cd "$NEW_DIR"
-
-OUTPUT_DIR=$NEW_DIR/output
+WORK_DIR=$(dirname "$0")
+OUTPUT_DIR=$WORK_DIR
 ZIP_FILE=$OUTPUT_DIR/wallpapers.zip
+MAX_KB=800
+
+echo "make-zip.sh: WORK_DIR=$WORK_DIR"
 echo "make-zip.sh: OUTPUT_DIR=$OUTPUT_DIR"
 echo "make-zip.sh: ZIP_FILE=$ZIP_FILE"
+echo "make-zip.sh: MAX_KB=$MAX_KB"
 
 if [ ! -d "$OUTPUT_DIR" ]; then
-    mkdir "$OUTPUT_DIR"
+    mkdir -p "$OUTPUT_DIR"
 fi
 
 if [ -f "$ZIP_FILE" ]; then
     rm "$ZIP_FILE"
 fi
 
-WALLPAPERS_LIST=`ls **{,/**}/*.{jpg,png,tif,gif,bmp} 2> /dev/null`
+# Find wallpapers and store them in an array
+# NOTE: We use Bash array to handle filenames with spaces correctly.
+mapfile -t WALLPAPERS_LIST < <(find "$WORK_DIR" -type f \( -iname "*.jpg" -o -iname "*.png" -o -iname "*.tif" -o -iname "*.gif" -o -iname "*.bmp" \) -print)
 
 # File size check
-for file in $WALLPAPERS_LIST; do
-    file_size=`wc -c "$file" | cut -d' ' -f1`
-    let KB="$file_size / 1024"
-    if [ $KB -gt 800 ]; then
-        let MB="$KB / 1024"
+for file in "${WALLPAPERS_LIST[@]}"; do
+    file_size=$(wc -c < "$file")
+    KB=$((file_size / 1024))
+    MB=$((KB / 1024))
+    if [ $KB -gt $MAX_KB ]; then
         if [ $MB -gt 1 ]; then
-            echo "make-zip.sh: WARNING: $file : $MB MB"
+            echo "make-zip.sh: WARNING: $file : $MB MB > $MAX_KB KB"
         else
-            echo "make-zip.sh: WARNING: $file : $KB KB"
+            echo "make-zip.sh: WARNING: $file : $KB KB > $MAX_KB KB"
         fi
     fi
 done
 
-cp -f README.md /tmp/README.txt
+cp -f "$WORK_DIR/README.md" /tmp/README.txt
 
-zip -j -q "$ZIP_FILE" $WALLPAPERS_LIST /tmp/README.txt LICENSE.txt
+zip -j -q "$ZIP_FILE" "${WALLPAPERS_LIST[@]}" /tmp/README.txt "$WORK_DIR/LICENSE.txt"
 
 if [ "$?" -eq "0" ] && [ -f "$ZIP_FILE" ]; then
-    file_size=`wc -c "$ZIP_FILE" | cut -d' ' -f1`
-    let KB="$file_size / 1024"
-    let MB="$KB / 1024"
+    file_size=$(wc -c < "$ZIP_FILE")
+    KB=$((file_size / 1024))
+    MB=$((KB / 1024))
     if [ $MB -gt 1 ]; then
         echo "make-zip.sh: Generated $ZIP_FILE ($MB MB)"
     else
@@ -58,5 +59,3 @@ if [ "$?" -eq "0" ] && [ -f "$ZIP_FILE" ]; then
 fi
 
 rm /tmp/README.txt
-
-cd "$OLD_DIR"


### PR DESCRIPTION
- Make `make-zip.sh` current directory free.
- Use Bash array to handle filenames that contain spaces.
- Simplify logic.